### PR TITLE
Use native Vercel integration for provisioning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This example shows how to use Resend with React Email + Next.js + Vercel.
 
 Deploy the example using [Vercel](https://vercel.com):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/resend/resend-vercel-example&project-name=resend-vercel-example&repository-name=resend-vercel-example&env=RESEND_API_KEY)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/resend/resend-vercel-example&project-name=resend-vercel-example&repository-name=resend-vercel-example&products=%255B%257B%2522type%2522%253A%2522integration%2522%252C%2522protocol%2522%253A%2522other%2522%252C%2522productSlug%2522%253A%2522resend-email%2522%252C%2522integrationSlug%2522%253A%2522resend%2522%257D%255D)
 
 ## Instructions
 


### PR DESCRIPTION
## What

Updates the **Deploy with Vercel** button so it provisions Resend through the [native Marketplace integration](https://vercel.com/marketplace/resend) instead of the connected-account flow.

Previously the button used `&env=RESEND_API_KEY`, which required the user to paste an API key by hand during deploy. This switches to the `products` query parameter, which provisions a Resend resource as part of the deploy flow and automatically injects `RESEND_API_KEY` into the project's environment.

## How

The deploy URL now carries a (double URL-encoded) `products` payload:

```json
[{ "type": "integration", "protocol": "other", "productSlug": "resend-email", "integrationSlug": "resend" }]
```

This mirrors the approach used in [vercel/commerce#1531](https://github.com/vercel/commerce/pull/1531), which adopted the same `products` field for Shopify.

See the [Deploy Button source docs](https://vercel.com/docs/deploy-button/source) for the `products`/integration parameter reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)