### PR TITLE
switch to the native integration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This example shows how to use Resend with React Email + Next.js + Vercel.
 
 Deploy the example using [Vercel](https://vercel.com):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/resend/resend-vercel-example&project-name=resend-vercel-example&repository-name=resend-vercel-example&env=RESEND_API_KEY)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/resend/resend-vercel-example&project-name=resend-vercel-example&repository-name=resend-vercel-example&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22resend%22%2C%22productSlug%22%3A%22resend-email%22%2C%22protocol%22%3A%22messaging%22%7D%5D)
 
 ## Instructions
 


### PR DESCRIPTION
Update the "Deploy with Vercel" button to use the native Resend Marketplace integration instead of a plain `RESEND_API_KEY` env var prompt.

The clone URL now passes a `products` param that provisions the Resend integration (`resend-email` product, `messaging` protocol) automatically during deploy, so the API key is wired up via the Marketplace rather than entered manually.

## Changes
- `readme.md`: swap the deploy button's `env=RESEND_API_KEY` for the native integration `products` payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)